### PR TITLE
Mongo Repository'de Ortam Değişkenine Bağlı Koşullu Hata Fırlatma Mekanizması Eklendi

### DIFF
--- a/DMicroservices/DMicroservices.csproj
+++ b/DMicroservices/DMicroservices.csproj
@@ -6,12 +6,12 @@
 		<RepositoryUrl>https://github.com/detayteknoloji/dmicroservices</RepositoryUrl>
 		<Authors>Serhat Boyraz</Authors>
 		<Company>Detaysoft</Company>
-		<Version>3.1.100</Version>
+		<Version>3.0.100</Version>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<OutputType>Library</OutputType>
 		<IsPackable>true</IsPackable>
-		<AssemblyVersion>3.1.100</AssemblyVersion>
-		<FileVersion>3.1.100</FileVersion>
+		<AssemblyVersion>3.0.100</AssemblyVersion>
+		<FileVersion>3.0.100</FileVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/DMicroservices/DMicroservices.csproj
+++ b/DMicroservices/DMicroservices.csproj
@@ -6,12 +6,12 @@
 		<RepositoryUrl>https://github.com/detayteknoloji/dmicroservices</RepositoryUrl>
 		<Authors>Serhat Boyraz</Authors>
 		<Company>Detaysoft</Company>
-		<Version>3.0.99</Version>
+		<Version>3.1.100</Version>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<OutputType>Library</OutputType>
 		<IsPackable>true</IsPackable>
-		<AssemblyVersion>3.0.99</AssemblyVersion>
-		<FileVersion>3.0.99</FileVersion>
+		<AssemblyVersion>3.1.100</AssemblyVersion>
+		<FileVersion>3.1.100</FileVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/DMicroservices/DataAccess/MongoRepository/MongoRepository.cs
+++ b/DMicroservices/DataAccess/MongoRepository/MongoRepository.cs
@@ -1,6 +1,7 @@
 ﻿using DMicroservices.DataAccess.DynamicQuery.Enum;
 using DMicroservices.DataAccess.MongoRepository.Interfaces;
 using DMicroservices.DataAccess.MongoRepository.Settings;
+using DMicroservices.Utils.Logger;
 using MongoDB.Driver;
 using System;
 using System.Collections.Generic;
@@ -8,7 +9,6 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
-using DMicroservices.Utils.Logger;
 
 namespace DMicroservices.DataAccess.MongoRepository
 {
@@ -158,11 +158,13 @@ namespace DMicroservices.DataAccess.MongoRepository
             }
             catch (Exception ex)
             {
+                IfThrowError(ex);
                 string messageTemplate = $"Mongo adding error on :{typeof(T).Name}";
                 ElasticLogger.Instance.Error(ex, messageTemplate);
                 return false;
             }
         }
+
 
         public bool Delete(Expression<Func<T, bool>> predicate, bool forceDelete = false)
         {
@@ -173,6 +175,7 @@ namespace DMicroservices.DataAccess.MongoRepository
             }
             catch (Exception ex)
             {
+                IfThrowError(ex);
                 string messageTemplate = $"Mongo deleting error on :{typeof(T).Name}";
                 ElasticLogger.Instance.Error(ex, messageTemplate);
                 return false;
@@ -189,6 +192,7 @@ namespace DMicroservices.DataAccess.MongoRepository
             }
             catch (Exception ex)
             {
+                IfThrowError(ex);
                 string messageTemplate = $"Mongo delete many error on :{typeof(T).Name}";
                 ElasticLogger.Instance.Error(ex, messageTemplate);
                 return false;
@@ -204,6 +208,7 @@ namespace DMicroservices.DataAccess.MongoRepository
             }
             catch (Exception ex)
             {
+                IfThrowError(ex);
                 string messageTemplate = $"Mongo upate many error on :{typeof(T).Name}";
                 ElasticLogger.Instance.Error(ex, messageTemplate);
                 return false;
@@ -351,5 +356,15 @@ namespace DMicroservices.DataAccess.MongoRepository
             return false;
         }
 
+        private void IfThrowError(Exception e)
+        {
+            bool throwAnError =
+               !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("THROW_MONGO_ERROR"))
+                   ? bool.Parse(Environment.GetEnvironmentVariable("THROW_MONGO_ERROR"))
+                   : false;
+
+            if (throwAnError)
+                throw e;
+        }
     }
 }

--- a/Tests/DMicroservices.DataAccess.Tests/Properties/launchSettings.json
+++ b/Tests/DMicroservices.DataAccess.Tests/Properties/launchSettings.json
@@ -10,7 +10,8 @@
         "THROW_UNIT_OF_WORK_ERROR": "true",
         "ELASTIC_URI": "http://localhost:13030",
         "LOG_INDEX_FORMAT": "serilog-{0:yyyy.MM.dd}",
-        "REDIS_URL": "127.0.0.1:13036"
+        "REDIS_URL": "127.0.0.1:13036",
+        "THROW_MONGO_ERROR": "false"
       }
     }
   }


### PR DESCRIPTION
Bu güncelleme, Mongo repository sınıfında hata fırlatma işlemini ortam değişkeni THROW_MONGO_ERROR'a bağlı olarak koşullu hale getiren bir mekanizma ekler.

Ana Değişiklikler:
IfThrowError(Exception e) adında yeni bir özel metod eklendi. Bu metod, THROW_MONGO_ERROR ortam değişkeninin değerini kontrol eder.
Ortam değişkeni true olarak ayarlanmışsa, metod hatayı fırlatır; aksi takdirde hata fırlatılmadan yönetilir.
Varsayılan olarak, eğer ortam değişkeni tanımlanmamış veya geçersiz bir değere sahipse, metod hata fırlatmadan devam eder (değer false kabul edilir).