### PR TITLE
Bump version to 3.1.112 and improve logging

### DIFF
--- a/DMicroservices/DMicroservices.csproj
+++ b/DMicroservices/DMicroservices.csproj
@@ -6,12 +6,12 @@
 		<RepositoryUrl>https://github.com/detayteknoloji/dmicroservices</RepositoryUrl>
 		<Authors>Serhat Boyraz</Authors>
 		<Company>Detaysoft</Company>
-		<Version>3.1.111</Version>
+		<Version>3.1.112</Version>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<OutputType>Library</OutputType>
 		<IsPackable>true</IsPackable>
-		<AssemblyVersion>3.1.111</AssemblyVersion>
-		<FileVersion>3.1.111</FileVersion>
+		<AssemblyVersion>3.1.112</AssemblyVersion>
+		<FileVersion>3.1.112</FileVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/DMicroservices/DataAccess/Redis/RedisManagerV2.cs
+++ b/DMicroservices/DataAccess/Redis/RedisManagerV2.cs
@@ -73,7 +73,7 @@ namespace DMicroservices.DataAccess.Redis
 
                 try
                 {
-                    LogInfo("Redis Bağlantısı kurmak istenildi, yeni connection açılmak veya eski connection ezilmek züere multiplexer acilacak");
+                    LogInfo("Redis Bağlantısı kurmak istenildi, yeni connection açılmak veya eski connection ezilmek üzere multiplexer acilacak");
                     var options = ConfigurationOptions.Parse(_redisUrl);
                     options.AbortOnConnectFail = false;
                     options.ClientName = $"Container-{_containerPodName}";
@@ -601,7 +601,6 @@ namespace DMicroservices.DataAccess.Redis
                         {
                             lock (_circuitLock) { if (_isCircuitOpen) _isCircuitOpen = false; }
                         }
-                        LogInfo("Redis connection tekrar açıldı, bağlantı koruması devre dışı bırakıldı!");
 
                         yield return enumerator.Current;
                     }

--- a/DMicroservices/Utils/Logger/ElasticLogger.cs
+++ b/DMicroservices/Utils/Logger/ElasticLogger.cs
@@ -342,7 +342,7 @@ namespace DMicroservices.Utils.Logger
             var loggerConfiguration = new LoggerConfiguration()
               .MinimumLevel.Verbose()
               .WriteTo.File($"{combinedPath}-.txt", fileSizeLimitBytes: 40971520, rollingInterval: RollingInterval.Day, rollOnFileSizeLimit: true,
-              outputTemplate: outputTemplate);
+              outputTemplate: outputTemplate, shared: true);
 
             if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("POD_NAME")))
                 loggerConfiguration.Enrich.WithProperty("PodName", Environment.GetEnvironmentVariable("POD_NAME"));


### PR DESCRIPTION
Updated `DMicroservices.csproj` to increment version numbers to `3.1.112`. Modified log messages in `RedisManagerV2.cs` for clarity and removed unnecessary logging. Enhanced logger configuration in `ElasticLogger.cs` to support concurrent writes by adding `shared: true`.