### PR TITLE
Sürüm 3.1.113 upgrade ve Delete filterExp geçildi

### DIFF
--- a/DMicroservices/DMicroservices.csproj
+++ b/DMicroservices/DMicroservices.csproj
@@ -6,12 +6,12 @@
 		<RepositoryUrl>https://github.com/detayteknoloji/dmicroservices</RepositoryUrl>
 		<Authors>Serhat Boyraz</Authors>
 		<Company>Detaysoft</Company>
-		<Version>3.1.112</Version>
+		<Version>3.1.113</Version>
 		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 		<OutputType>Library</OutputType>
 		<IsPackable>true</IsPackable>
-		<AssemblyVersion>3.1.112</AssemblyVersion>
-		<FileVersion>3.1.112</FileVersion>
+		<AssemblyVersion>3.1.113</AssemblyVersion>
+		<FileVersion>3.1.113</FileVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/DMicroservices/DataAccess/Repository/FilteredRepository.cs
+++ b/DMicroservices/DataAccess/Repository/FilteredRepository.cs
@@ -112,7 +112,7 @@ namespace DMicroservices.DataAccess.Repository
 
         public void Delete(Expression<Func<T, bool>> predicate, bool forceDelete = false)
         {
-            T model = DbSet.FirstOrDefault(predicate);
+            T model = DbSet.Where(GetFilterExpression()).FirstOrDefault(predicate);
 
             if (model != null)
                 Delete(model, forceDelete);


### PR DESCRIPTION
`DMicroservices.csproj` dosyasında `Version`, `AssemblyVersion` ve `FileVersion` alanları 3.1.113 olarak güncellendi.

`FilteredRepository.cs` dosyasındaki `Delete` metodu, silinecek entity'nin daha doğru bulunabilmesi için artık `DbSet.Where(GetFilterExpression()).FirstOrDefault(predicate)` kullanıyor.